### PR TITLE
Enabling blank issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: CYF
     url: contact@codeyourfuture.io


### PR DESCRIPTION
## Changelist
Enabled blank issue so that learners/trainees can create blank issue to submit their work on the Course Platform.