### PR TITLE
Fix: Change plain email to mailto: link in config.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: CYF
-    url: contact@codeyourfuture.io
+url: mailto:contact@codeyourfuture.io
     about: Please report serious issues here.
   - name: Join CYF
     url: https://codeyourfuture.io/volunteers/


### PR DESCRIPTION
This pull request fixes the email link in `.github/ISSUE_TEMPLATE/config.yml`.

Changed:
- From: `contact@codeyourfuture.io`
- To: `mailto:contact@codeyourfuture.io`

This change makes the email a valid URL according to GitHub’s expected format for `contact_links`. This prevents potential config validation issues and makes the link clickable.
